### PR TITLE
refactor(cert-manager, onepassword): remove unnecessary namespace dependencies

### DIFF
--- a/openshift/apps/cert-manager/cert-manager/ks.yaml
+++ b/openshift/apps/cert-manager/cert-manager/ks.yaml
@@ -32,7 +32,6 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: onepassword-store
-      namespace: external-secrets
   interval: 30m
   path: ./openshift/apps/cert-manager/cert-manager/issuers
   prune: true
@@ -56,9 +55,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: cert-manager-issuers
-      namespace: cert-manager
     - name: onepassword-store
-      namespace: external-secrets
   interval: 30m
   path: ./openshift/apps/cert-manager/cert-manager/tls
   prune: true

--- a/openshift/apps/external-secrets/onepassword/ks.yaml
+++ b/openshift/apps/external-secrets/onepassword/ks.yaml
@@ -32,7 +32,6 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: onepassword
-      namespace: external-secrets
   interval: 30m
   path: ./openshift/apps/external-secrets/onepassword/store
   prune: true


### PR DESCRIPTION
This commit removes the namespace specification from the 'dependsOn' section in the ks.yaml files for cert-manager and onepassword. The namespace was deemed unnecessary for the dependencies listed, simplifying the configuration.