### PR TITLE
feat(vault): update helmrelease to specify vault image repository and tag

### DIFF
--- a/openshift/apps/infra/vault/app/helmrelease.yaml
+++ b/openshift/apps/infra/vault/app/helmrelease.yaml
@@ -31,6 +31,9 @@ spec:
       openshift: true
     server:
       enabled: true
+      image:
+        repository: "hashicorp/vault"
+        tag: "1.19.0"
       updateStrategyType: RollingUpdate
       readinessProbe:
         enabled: true


### PR DESCRIPTION
Added image repository and tag for the Vault server in the helmrelease.yaml to ensure the newest version (1.19.0) is used.