### PR TITLE
chore(helmrelease): update NetBox image tag to v4.2.6-3.2.0

### DIFF
--- a/openshift/apps/infra/netbox/app/helmrelease.yaml
+++ b/openshift/apps/infra/netbox/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
         reloader.stakater.com/auto: "true"
     image:
       repository: "netboxcommunity/netbox"
-      tag: "v4.2.3-3.2.0"
+      tag: "v4.2.6-3.2.0"
     envFrom:
       - secretRef:
           name: netbox-secret


### PR DESCRIPTION
Updated the NetBox image tag in the Helm release configuration from v4.2.3-3.2.0 to v4.2.6-3.2.0 to ensure the deployment uses the latest version with improvements and bug fixes.