### PR TITLE
feat(cluster): add enablePDB field to cluster configuration

### DIFF
--- a/openshift/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/openshift/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16.6@sha256:d7822fa6eba284a6d3d035d51a51de22147bc5e72d87aa93e7dd9fa87455ed5c
   instances: 3
+  enablePDB: false
   primaryUpdateStrategy: unsupervised
   storage:
     size: 60Gi


### PR DESCRIPTION
Added the `enablePDB` field set to `false` in the cluster configuration to manage Pod Disruption Budgets. This change allows for better control over pod availability during disruptions.